### PR TITLE
Seperating the OptionListPanel into a standalone component

### DIFF
--- a/Control/Components/OptionListPanel.xaml
+++ b/Control/Components/OptionListPanel.xaml
@@ -1,0 +1,47 @@
+﻿<UserControl x:Class="Control.Components.OptionListPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:selectors="clr-namespace:Control.Others.Templates"
+             xmlns:local="clr-namespace:Control.Components"
+             mc:Ignorable="d" 
+             Name="AllOptionListsPanel"
+             d:DesignHeight="450" d:DesignWidth="800">
+    
+    <UserControl.Resources>
+        <selectors:OptionListTemplateSelector x:Key="OptionListSelector">
+            <selectors:OptionListTemplateSelector.SystemOptionListTemplate>
+                <DataTemplate>
+                    <local:SystemOptionsDropDownMenu
+                    ListName="{Binding Name}"
+                    Options="{Binding Options}"
+                    SelectedItem="{Binding SelectedOption}"
+                    Margin="10,0,10,0" />
+                </DataTemplate>
+            </selectors:OptionListTemplateSelector.SystemOptionListTemplate>
+
+            <selectors:OptionListTemplateSelector.UserAndMixedOptionListTemplate>
+                <DataTemplate>
+                    <local:UserOptionsDropDownMenu
+                    ListName="{Binding Name}"
+                    Options="{Binding Options}"
+                    SelectedItem="{Binding SelectedOption}"
+                    AddOptionCommand="{Binding AddOptionCommand}"
+                    NewOptionName="{Binding NewOptionName}"
+                    Margin="10,0,10,0" />
+                </DataTemplate>
+            </selectors:OptionListTemplateSelector.UserAndMixedOptionListTemplate>
+        </selectors:OptionListTemplateSelector>
+    </UserControl.Resources>
+
+    <ItemsControl ItemsSource="{Binding OptionLists, ElementName=AllOptionListsPanel}"
+              ItemTemplateSelector="{StaticResource OptionListSelector}">
+        <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+                <StackPanel Orientation="Horizontal" Margin="20,10,20,0" HorizontalAlignment="Left" VerticalAlignment="Top" 
+                Height="Auto" />
+            </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+    </ItemsControl>
+</UserControl>

--- a/Control/Components/OptionListPanel.xaml.cs
+++ b/Control/Components/OptionListPanel.xaml.cs
@@ -1,0 +1,27 @@
+﻿using Control.ViewModel;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Control.Components
+{
+    public partial class OptionListPanel : UserControl
+    {
+        public static readonly DependencyProperty OptionListsProperty =
+            DependencyProperty.Register(
+                "OptionLists",
+                typeof(HashSet<BaseOptionListViewModel>),
+                typeof(OptionListPanel),
+                new PropertyMetadata(null));
+
+        public HashSet<BaseOptionListViewModel> OptionLists
+        {
+            get { return (HashSet<BaseOptionListViewModel>)GetValue(OptionListsProperty); }
+            set { SetValue(OptionListsProperty, value); }
+        }
+
+        public OptionListPanel()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Control/Components/UserOptionsDropDownMenu.xaml
+++ b/Control/Components/UserOptionsDropDownMenu.xaml
@@ -26,7 +26,7 @@
                 </StackPanel>
                 <ComboBox
                     ItemsSource="{Binding Options, ElementName=UserOptionsListDropDownMenu}"
-                    SelectedItem="{Binding SelectedItem, ElementName=UserOptionsListDropDownMenu, Mode=TwoWay}"
+                    SelectedItem="{Binding SelectedItem, ElementName=UserOptionsListDropDownMenu}"
                     DisplayMemberPath="Value"
                     IsEditable="False"
                     Width="200"/>

--- a/Demo/Windows/DropDownMenusWindow.xaml
+++ b/Demo/Windows/DropDownMenusWindow.xaml
@@ -3,45 +3,11 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:selectors="clr-namespace:Control.Others.Templates;assembly=Control"
-        xmlns:local="clr-namespace:Control.Components;assembly=Control"
+        xmlns:panel="clr-namespace:Control.Components;assembly=Control"
         mc:Ignorable="d"
         Title="Option Manager" Height="700" Width="1300">
 
-    <Window.Resources>
-        <selectors:OptionListTemplateSelector x:Key="OptionListSelector">
-            <selectors:OptionListTemplateSelector.SystemOptionListTemplate>
-                <DataTemplate>
-                    <local:SystemOptionsDropDownMenu
-                        ListName="{Binding Name}"
-                        Options="{Binding Options}"
-                        SelectedItem="{Binding SelectedOption}"
-                        Margin="10,0,10,0" />
-                </DataTemplate>
-            </selectors:OptionListTemplateSelector.SystemOptionListTemplate>
-
-            <selectors:OptionListTemplateSelector.UserAndMixedOptionListTemplate>
-                <DataTemplate>
-                    <local:UserOptionsDropDownMenu
-                        ListName="{Binding Name}"
-                        Options="{Binding Options}"
-                        SelectedItem="{Binding SelectedOption}"
-                        AddOptionCommand="{Binding AddOptionCommand}"
-                        NewOptionName="{Binding NewOptionName}"
-                        Margin="10,0,10,0" />
-                </DataTemplate>
-            </selectors:OptionListTemplateSelector.UserAndMixedOptionListTemplate>
-        </selectors:OptionListTemplateSelector>
-    </Window.Resources>
-    
-    <ItemsControl ItemsSource="{Binding OptionLists}"
-                  ItemTemplateSelector="{StaticResource OptionListSelector}">
-        <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-                <StackPanel Orientation="Horizontal" Margin="20,10,20,0" HorizontalAlignment="Left" VerticalAlignment="Top" 
-                    Height="Auto" />
-            </ItemsPanelTemplate>
-        </ItemsControl.ItemsPanel>
-    </ItemsControl>
+    <panel:OptionListPanel
+        OptionLists="{Binding OptionLists}"/>
     
 </Window>


### PR DESCRIPTION
Making the OptionLists panel into a seperate component that requires a HashSet<BaseOptionListViewModel> as a Property.